### PR TITLE
회원가입/ 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
 	testImplementation 'org.springframework.batch:spring-batch-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sayjong/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sayjong/backend/config/JwtAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package com.sayjong.backend.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    //요청이 들어올 때마다 JWT 토큰을 검사하여 인증을 처리
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        String token = resolveToken((HttpServletRequest) request); //Request Header에서 JWT 토큰 추출
+
+        //토큰이 존재하고 유효한지 확인
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+
+    //요청 헤더에서 Bearer 접두사를 제거하고 순수한 토큰 추출
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/sayjong/backend/config/JwtTokenProvider.java
+++ b/src/main/java/com/sayjong/backend/config/JwtTokenProvider.java
@@ -39,8 +39,8 @@ public class JwtTokenProvider {
 
         long now = (new Date()).getTime();
 
+        //AccessToken 생성
         Date accessTokenExpiresIn = new Date(now + 1000 * 60 * 30); //토큰 만료 시간(30분)
-
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim("auth", authorities)
@@ -48,9 +48,16 @@ public class JwtTokenProvider {
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
+        //RefreshToken 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + 1000 * 60 * 60 * 24 * 7)) //토큰 만료 시간(7일)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
         return TokenInfo.builder()
                 .grantType("Bearer")
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/com/sayjong/backend/config/JwtTokenProvider.java
+++ b/src/main/java/com/sayjong/backend/config/JwtTokenProvider.java
@@ -1,0 +1,99 @@
+package com.sayjong.backend.config;
+
+import com.sayjong.backend.user.dto.TokenInfo;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8); //문자열을 바이트로 반환
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    //유저 정보를 가지고 토큰을 생성
+    public TokenInfo generateToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        Date accessTokenExpiresIn = new Date(now + 1000 * 60 * 30); //토큰 만료 시간(30분)
+
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return TokenInfo.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .build();
+    }
+
+    //토큰을 복호화하여 JWT 토큰에 들어있는 정보를 꺼냄
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    //토큰의 유효성을 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    //토큰에서 정보 추출
+    private Claims parseClaims(String accessToken) {
+        try {   //토큰이 유효하면 내용물을 바로 반환
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) { //토큰이 만료되었다면 프로그램을 멈추지 않고 예외 안의 내용물을 꺼내서 반환
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/sayjong/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sayjong/backend/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 //TODO(jiho): 빠른 healthcheck를 위해 임시로 security를 비활성화합니다. 제거 예정!
@@ -23,5 +25,10 @@ public class SecurityConfig {
 			);
 
 		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() { //비밀번호 암호화
+		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/com/sayjong/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sayjong/backend/config/SecurityConfig.java
@@ -1,18 +1,22 @@
 package com.sayjong.backend.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 //TODO(jiho): 빠른 healthcheck를 위해 임시로 security를 비활성화합니다. 제거 예정!
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
-	@Bean
+	/*@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 			// CSRF 보호 비활성화 (개발 초기 단계에서는 편리함을 위해 비활성화)
@@ -23,6 +27,33 @@ public class SecurityConfig {
 				// 모든 요청(anyRequest)을 허용(permitAll)
 				.anyRequest().permitAll()
 			);
+
+		return http.build();
+	}*/
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+				//CSRF 보호 비활성화 (개발 초기 단계에서는 편리함을 위해 비활성화)
+				.csrf(csrf -> csrf.disable())
+
+				//HTTP Basic 인증 비활성화
+				.httpBasic(httpBasic -> httpBasic.disable())
+
+				//세션 STATELESS 설정
+				.sessionManagement(sessionManagement ->
+						sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+				)
+
+				//요청 경로별 권한 설정
+				.authorizeHttpRequests(auth -> auth
+						.requestMatchers("/auth/**").permitAll()  //해당 경로는 모두 허용
+						.anyRequest().authenticated()  // 나머지 모든 요청은 인증 필요
+				)
+
+				//JWT 인증 필터
+				.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/com/sayjong/backend/user/controller/UserController.java
+++ b/src/main/java/com/sayjong/backend/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.sayjong.backend.user.controller;
 
 import com.sayjong.backend.user.dto.TokenInfo;
+import com.sayjong.backend.user.dto.TokenRefreshRequestDto;
 import com.sayjong.backend.user.dto.UserLoginRequestDto;
 import com.sayjong.backend.user.dto.UserSignUpRequestDto;
 import com.sayjong.backend.user.service.UserService;
@@ -43,6 +44,19 @@ public class UserController {
             //이메일 또는 비밀번호가 틀린 경우
             log.warn("Login failed for email: {}", requestDto.getEmail());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("이메일 또는 비밀번호가 일치하지 않습니다.");
+        }
+    }
+
+    //토큰 재발급
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(@RequestBody TokenRefreshRequestDto requestDto) {
+        try {
+            TokenInfo tokenInfo = userService.reissueToken(requestDto.getRefreshToken());
+            return ResponseEntity.ok(tokenInfo);
+        } catch (RuntimeException e) {
+            //유효하지 않은 토큰이나 사용자를 찾을 수 없을 때
+            log.warn("Token refresh failed: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/sayjong/backend/user/controller/UserController.java
+++ b/src/main/java/com/sayjong/backend/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.sayjong.backend.user.controller;
+
+import com.sayjong.backend.user.dto.UserSignUpRequestDto;
+import com.sayjong.backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")  //회원가입
+    public ResponseEntity<String> signUp(@RequestBody UserSignUpRequestDto requestDto) {
+        try {
+            userService.registerUser(requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 성공적으로 완료되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/sayjong/backend/user/controller/UserController.java
+++ b/src/main/java/com/sayjong/backend/user/controller/UserController.java
@@ -1,15 +1,20 @@
 package com.sayjong.backend.user.controller;
 
+import com.sayjong.backend.user.dto.TokenInfo;
+import com.sayjong.backend.user.dto.UserLoginRequestDto;
 import com.sayjong.backend.user.dto.UserSignUpRequestDto;
 import com.sayjong.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -17,13 +22,27 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/signup")  //회원가입
+    //회원가입
+    @PostMapping("/signup")
     public ResponseEntity<String> signUp(@RequestBody UserSignUpRequestDto requestDto) {
         try {
             userService.registerUser(requestDto);
             return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 성공적으로 완료되었습니다.");
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+    //로그인
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody UserLoginRequestDto requestDto) {
+        try {
+            TokenInfo tokenInfo = userService.login(requestDto);
+            return ResponseEntity.ok(tokenInfo);
+        } catch (AuthenticationException e) {
+            //이메일 또는 비밀번호가 틀린 경우
+            log.warn("Login failed for email: {}", requestDto.getEmail());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("이메일 또는 비밀번호가 일치하지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/sayjong/backend/user/domain/User.java
+++ b/src/main/java/com/sayjong/backend/user/domain/User.java
@@ -23,4 +23,12 @@ public class User {
 
     @Column(nullable = false, length = 20)
     private String nickname;  //유저닉네임
+
+    @Column
+    private String refreshToken; //리프레시 토큰
+
+    //새로운 리프레시 토큰으로 갱신
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/sayjong/backend/user/domain/User.java
+++ b/src/main/java/com/sayjong/backend/user/domain/User.java
@@ -15,7 +15,7 @@ public class User {
     @Column(nullable = false)
     private Integer userId;  //유저식별자(PK)
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false)
     private String userPassword;  //유저비밀번호
 
     @Column(nullable = false, length = 50, unique = true)

--- a/src/main/java/com/sayjong/backend/user/dto/TokenInfo.java
+++ b/src/main/java/com/sayjong/backend/user/dto/TokenInfo.java
@@ -10,4 +10,5 @@ import lombok.Data;
 public class TokenInfo {
     private String grantType;
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/sayjong/backend/user/dto/TokenInfo.java
+++ b/src/main/java/com/sayjong/backend/user/dto/TokenInfo.java
@@ -1,0 +1,13 @@
+package com.sayjong.backend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class TokenInfo {
+    private String grantType;
+    private String accessToken;
+}

--- a/src/main/java/com/sayjong/backend/user/dto/TokenRefreshRequestDto.java
+++ b/src/main/java/com/sayjong/backend/user/dto/TokenRefreshRequestDto.java
@@ -1,0 +1,10 @@
+package com.sayjong.backend.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TokenRefreshRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/sayjong/backend/user/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/sayjong/backend/user/dto/UserLoginRequestDto.java
@@ -1,0 +1,11 @@
+package com.sayjong.backend.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserLoginRequestDto {
+    private String email;
+    private String userPassword;
+}

--- a/src/main/java/com/sayjong/backend/user/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/sayjong/backend/user/dto/UserSignUpRequestDto.java
@@ -1,0 +1,12 @@
+package com.sayjong.backend.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserSignUpRequestDto {
+    private String email;
+    private String userPassword;
+    private String nickname;
+}

--- a/src/main/java/com/sayjong/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/sayjong/backend/user/repository/UserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
-    //이메일로 사용자를 찾음
-    Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmail(String email); //이메일로 사용자를 찾음
+    Optional<User> findByRefreshToken(String refreshToken); //리프레시 토큰으로 사용자를 찾음
 }

--- a/src/main/java/com/sayjong/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/sayjong/backend/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.sayjong.backend.user.repository;
+
+import com.sayjong.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+    //이메일로 사용자를 찾음
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/sayjong/backend/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/sayjong/backend/user/service/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package com.sayjong.backend.user.service;
+
+import com.sayjong.backend.user.domain.User;
+import com.sayjong.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    //사용자가 입력한 아이디를 가진 User 객체가 실제로 존재하는지 확인
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByEmail(username)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다."));
+    }
+
+    //User 객체를 스프링 시큐리티가 사용하는 표준 사용자 정보 형식으로 변환
+    private UserDetails createUserDetails(User user) {
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getEmail())
+                .password(user.getUserPassword())
+                .roles("USER") //기본 역할 부여
+                .build();
+    }
+}

--- a/src/main/java/com/sayjong/backend/user/service/UserService.java
+++ b/src/main/java/com/sayjong/backend/user/service/UserService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,6 +57,39 @@ public class UserService {
         //검증된 인증 정보를 기반으로 JWT 토큰 생성
         TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
 
+        //DB에서 사용자 정보를 찾아 Refresh Token저장
+        User user = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 사용자를 찾을 수 없습니다."));
+        user.updateRefreshToken(tokenInfo.getRefreshToken());
+
         return tokenInfo;
+    }
+
+    @Transactional
+    public TokenInfo reissueToken(String refreshToken) {  //토큰 재발급
+        //리프레시 토큰 유효성 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new RuntimeException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        //DB에 저장된 토큰과 일치하는지 확인하여 사용자 정보 가져오기
+        User user = userRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new RuntimeException("리프레시 토큰에 해당하는 사용자가 없습니다."));
+
+        //사용자 정보를 바탕으로 새로운 인증 객체 생성
+        UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
+                .username(user.getEmail())
+                .password("")
+                .roles("USER")
+                .build();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+
+        //새로운 토큰 생성
+        TokenInfo newTokenInfo = jwtTokenProvider.generateToken(authentication);
+
+        //DB에 새로운 리프레시 토큰으로 갱신
+        user.updateRefreshToken(newTokenInfo.getRefreshToken());
+
+        return newTokenInfo;
     }
 }

--- a/src/main/java/com/sayjong/backend/user/service/UserService.java
+++ b/src/main/java/com/sayjong/backend/user/service/UserService.java
@@ -1,0 +1,38 @@
+package com.sayjong.backend.user.service;
+
+import com.sayjong.backend.user.domain.User;
+import com.sayjong.backend.user.dto.UserSignUpRequestDto;
+import com.sayjong.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public User registerUser(UserSignUpRequestDto requestDto) {  //회원가입
+        //이메일 중복 확인
+        if (userRepository.findByEmail(requestDto.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        //비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(requestDto.getUserPassword());
+
+        //사용자 정보 생성
+        User newUser = User.builder()
+                .email(requestDto.getEmail())
+                .userPassword(encodedPassword) //암호화된 비밀번호로 저장
+                .nickname(requestDto.getNickname())
+                .build();
+
+        //사용자 정보 저장
+        return userRepository.save(newUser);
+    }
+}

--- a/src/main/java/com/sayjong/backend/user/service/UserService.java
+++ b/src/main/java/com/sayjong/backend/user/service/UserService.java
@@ -1,9 +1,15 @@
 package com.sayjong.backend.user.service;
 
+import com.sayjong.backend.config.JwtTokenProvider;
 import com.sayjong.backend.user.domain.User;
+import com.sayjong.backend.user.dto.TokenInfo;
+import com.sayjong.backend.user.dto.UserLoginRequestDto;
 import com.sayjong.backend.user.dto.UserSignUpRequestDto;
 import com.sayjong.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +20,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public User registerUser(UserSignUpRequestDto requestDto) {  //회원가입
@@ -34,5 +42,19 @@ public class UserService {
 
         //사용자 정보 저장
         return userRepository.save(newUser);
+    }
+
+    @Transactional
+    public TokenInfo login(UserLoginRequestDto requestDto) { //로그인
+        //AuthenticationToken 생성
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(requestDto.getEmail(), requestDto.getUserPassword());
+
+        //비밀번호 일치 여부 검증
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        //검증된 인증 정보를 기반으로 JWT 토큰 생성
+        TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+
+        return tokenInfo;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,7 @@ spring:
   batch:
     jdbc:
       platform: mysql
+
+# JWT 설정 추가
+jwt:
+  secret: sayjong-backend-secret-key-for-jwt-token-generation


### PR DESCRIPTION
# Pull requests
## 작업한 내용
- 유저비밀번호 길이 변경: 기존(length=20)->수정후(length=255)
(데이터베이스에 비밀번호가 암호화 되어 들어가기 때문에 길이 늘림)
- 자체 회원가입 구현
- 자체 로그인 구현
- 토큰 재발급 구현

## 실행화면 캡처
### 회원가입
- 회원가입(성공)
<img width="409" height="345" alt="회원가입" src="https://github.com/user-attachments/assets/c34c20c0-7bf0-4a28-846f-4c4230586705" />

- 회원가입(중복이메일로 다시 회원가입 시도시 400에러)
<img width="601" height="463" alt="회원가입-중복이메일" src="https://github.com/user-attachments/assets/632116a0-db39-4d85-bbac-fadf73400cb2" />

### 로그인
- 로그인(로그인 성공시 다음과 같이 토큰을 발급받음)
<img width="604" height="524" alt="스크린샷 2025-10-16 오전 12 25 36" src="https://github.com/user-attachments/assets/dc721c0e-3e58-4f04-addd-112cda600a46" />

- 로그인(입력정보(이메일또는 비번)가 일치하지 않는 경우 401에러)
<img width="601" height="463" alt="로그인-입력정보틀림" src="https://github.com/user-attachments/assets/2f33545c-d852-4698-b469-909e53d627c7" />

### 토큰 재발급
- 토큰 재발급(로그인에서 발급 받은 리프레시 토큰 이용)
<img width="604" height="533" alt="스크린샷 2025-10-16 오전 12 28 45" src="https://github.com/user-attachments/assets/fd4d487b-0548-454e-87a2-45526c21e8b7" />

### User데이터베이스
- User데이터베이스에 다음과 같은 형태로 저장됨(테스트유저2는 회원가입만 한 상태)
<img width="770" height="156" alt="스크린샷 2025-10-16 오전 1 00 53" src="https://github.com/user-attachments/assets/84464d6a-ba4e-4547-ab9b-8e1d300dbd96" />
