### PR TITLE
Refactor: 엔티티 PK 전략 변경 (그리고 song에 영문 제목 하나 추가)

### DIFF
--- a/src/main/java/com/sayjong/backend/lyric/domain/LyricLine.java
+++ b/src/main/java/com/sayjong/backend/lyric/domain/LyricLine.java
@@ -8,7 +8,8 @@ import lombok.*;
 @Entity
 @Table(
         name = "lyric_line",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"line_no", "song_id"})} //한 곡 안에서 각 소절번호는 유일해야함
+		// DB에서 (song_id, line_no) 조합이 중복되지 않도록 유니크 제약조건 설정
+		uniqueConstraints = {@UniqueConstraint(columnNames = {"song_id", "line_no"})}
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,8 +19,11 @@ public class LyricLine {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "lyric_line_id")
+	private Long lyricLineId;
+
     @Column(name = "line_no", nullable = false)
-    private Integer lineNo;  //소절번호(PK)
+    private Integer lineNo;  //소절번호 (a곡의 n번째 소절)
 
 	@Size(max = 100)
 	@Column(nullable = false, length = 100)

--- a/src/main/java/com/sayjong/backend/lyric/domain/LyricSyllable.java
+++ b/src/main/java/com/sayjong/backend/lyric/domain/LyricSyllable.java
@@ -7,7 +7,8 @@ import lombok.*;
 @Entity
 @Table(
         name = "lyric_syllable",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"syl_no", "line_no"})}
+		// 한 소절(lyric_line_id) 안에서 음절 번호(syl_no)가 중복되지 않도록 설정
+		uniqueConstraints = {@UniqueConstraint(columnNames = {"lyric_line_id", "syl_no"})}
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,8 +18,11 @@ public class LyricSyllable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false)
-    private Integer sylNo; //음절번호(PK)
+	@Column(name = "lyric_syllable_id")
+	private Long lyricSyllableId;
+
+	@Column(nullable = false)
+    private Integer sylNo; //음절번호 (소절 내 순서)
 
     @Size(max = 20)
     @Column(nullable = false, length = 20)
@@ -33,6 +37,6 @@ public class LyricSyllable {
     private String nativeAudioUrl; //원어민(한국어발음)오디오 URL
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "line_no", nullable = false)
-    private LyricLine lyricLine; //소절번호
+	@JoinColumn(name = "lyric_line_id", nullable = false)
+	private LyricLine lyricLine;
 }

--- a/src/main/java/com/sayjong/backend/song/domain/Song.java
+++ b/src/main/java/com/sayjong/backend/song/domain/Song.java
@@ -23,6 +23,10 @@ public class Song {
     @Column(nullable = false, length = 30)
     private String title;       //노래제목
 
+	@Size(max = 30)
+	@Column(nullable = false, length = 30)
+	private String titleEng;    //노래 영문 제목
+
     @Size(max = 20)
     @Column(nullable = false, length = 20)
     private String singer;      //가수

--- a/src/main/java/com/sayjong/backend/song/dto/SongResponseDto.java
+++ b/src/main/java/com/sayjong/backend/song/dto/SongResponseDto.java
@@ -7,7 +7,8 @@ public record SongResponseDto(
         String title,
         String singer,
         String trackId,
-        String coverUrl
+        String coverUrl,
+		String titleEng
 ) {
     public static SongResponseDto fromEntity(Song song) {
         return new SongResponseDto(
@@ -15,7 +16,8 @@ public record SongResponseDto(
                 song.getTitle(),
                 song.getSinger(),
                 song.getTrackId(),
-                song.getCoverUrl()
+                song.getCoverUrl(),
+				song.getTitleEng()
         );
     }
 }


### PR DESCRIPTION
### 1. 주요 변경점: Lyric 엔티티 PK 전략 수정 (대리키 방식 도입)

기존 `LyricLine`과 `LyricSyllable`은 각각 `lineNo`, `sylNo`를 단순 PK로 사용하고 있었습니다. 이 방식은 **"A곡의 1번 소절"과 "B곡의 1번 소절"이 공존할 수 없는** 근본적인 한계가 있었습니다.

이 문제를 해결하고 비즈니스 로직(곡별/소절별 순서)과 DB 식별자를 분리하기 위해 **대리키(Surrogate Key)** 전략으로 전면 수정했습니다.

* **`LyricLine.java`**
    * `lyricLineId` (Long)를 새로운 `GenerationType.IDENTITY` PK로 추가했습니다.
    * `lineNo`는 일반 필드로 변경하고, `song_id`와 묶어 `@UniqueConstraint`를 적용했습니다. (이제 `(song_id, line_no)` 조합이 유일합니다.)

* **`LyricSyllable.java`**
    * `lyricSyllableId` (Long)를 새로운 `GenerationType.IDENTITY` PK로 추가했습니다.
    * `sylNo`는 일반 필드로 변경하고, `lyric_line_id`와 묶어 `@UniqueConstraint`를 적용했습니다.
    * `@JoinColumn`의 `name`을 `line_no`에서 `lyric_line_id`로 수정하여, 부모인 `LyricLine`의 새 PK를 올바르게 참조하도록 변경했습니다.

### 2. 기능 추가: 노래 영문 제목

* **`Song.java`**: `titleEng` 필드를 추가했습니다.
* **`SongResponseDto.java`**: `Song` 엔티티의 `titleEng` 필드를 DTO에 포함하도록 수정했습니다.