### PR TITLE
🔧 Chore: docker 시스템 정리를 위해 deploy 워크플로우 업데이트

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,4 +21,4 @@ jobs:
             git pull origin main
             echo "${{ secrets.DOT_ENV }}" > .env
             docker-compose up -d --build
-            docker image prune -f
+            docker system prune -f


### PR DESCRIPTION
어제 서버 디스크가 꽉 차는 문제가 있었어서, 임시방편으로 배포 스크립트 마지막에 도커 관련 리소스를 쭉 정리하도록 워크플로우를 변경했습니다!

빌드 속도는 조금 느려질 수 있어도 docker system prune으로 빌드 캐시와 사용 안 하는 이미지를 전부 삭제하도록 했습니다

다음번에는 실제 배포 환경에서는 빌드를 안 하고, CI에서 jar 파일만 만들어서 서버에 올릴 수 있도록 더 변경해보도록 할게요~