### PR TITLE
🧱 Infra: docker-compose.yml에 host-gateway 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - DB_NAME=${DB_NAME}
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
sayjong-content-creation-pipeline 서버 배포 과정에서, spring서버가 node서버의 엔드포인트를 못 찾는 이슈가 있어 핫픽스로 dockercompose 파일을 수정합니다.