### PR TITLE
LyricLine 관련 api 구현

### DIFF
--- a/src/main/java/com/sayjong/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/sayjong/backend/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.sayjong.backend.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/sayjong/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sayjong/backend/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.sayjong.backend.global.exception;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.sayjong.backend.global.dto.ErrorResponseDto;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice // 모든 @RestController에서 발생하는 예외 처리
@@ -30,12 +33,19 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponseDto("아이디 또는 비밀번호가 일치하지 않습니다"));
     }
 
-    // RuntimeException처리
+    // RuntimeException 처리
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponseDto> handleRuntimeException(
             RuntimeException e) {
         log.warn("Unhandled runtime exception: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponseDto(e.getMessage()));
+    }
+
+    // EntityNotFoundException 처리
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleEntityNotFoundException(EntityNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", e.getMessage()));
     }
 }

--- a/src/main/java/com/sayjong/backend/lyric/controller/LyricLineController.java
+++ b/src/main/java/com/sayjong/backend/lyric/controller/LyricLineController.java
@@ -1,0 +1,31 @@
+package com.sayjong.backend.lyric.controller;
+
+import com.sayjong.backend.lyric.dto.response.LyricLineResponseDto;
+import com.sayjong.backend.lyric.service.LyricLineService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/songs")
+public class LyricLineController {
+
+    private final LyricLineService lyricLineService;
+
+    // 특정 노래의 전체 소절 정보 조회
+    @GetMapping("/{songId}/lyriclines")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<List<LyricLineResponseDto>> getLyricLinesBySong(
+            @PathVariable("songId") Integer songId
+    ) {
+        List<LyricLineResponseDto> lyricLines = lyricLineService.getLyricLinesBySongId(songId);
+        return ResponseEntity.ok(lyricLines);
+    }
+}

--- a/src/main/java/com/sayjong/backend/lyric/controller/LyricLineController.java
+++ b/src/main/java/com/sayjong/backend/lyric/controller/LyricLineController.java
@@ -1,5 +1,6 @@
 package com.sayjong.backend.lyric.controller;
 
+import com.sayjong.backend.lyric.domain.LyricLine;
 import com.sayjong.backend.lyric.dto.response.LyricLineResponseDto;
 import com.sayjong.backend.lyric.service.LyricLineService;
 import lombok.RequiredArgsConstructor;
@@ -27,5 +28,16 @@ public class LyricLineController {
     ) {
         List<LyricLineResponseDto> lyricLines = lyricLineService.getLyricLinesBySongId(songId);
         return ResponseEntity.ok(lyricLines);
+    }
+
+    // 특정 노래의 특정 소절 정보 조회
+    @GetMapping("/{songId}/lyriclines/{lineNo}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<LyricLineResponseDto> getSpecificLyricLine(
+            @PathVariable("songId") Integer songId,
+            @PathVariable("lineNo") Integer lineNo
+    ) {
+        LyricLineResponseDto lyricLineDto = lyricLineService.getLyricLineBySongIdAndLineNo(songId, lineNo);
+        return ResponseEntity.ok(lyricLineDto);
     }
 }

--- a/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineResponseDto.java
+++ b/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineResponseDto.java
@@ -1,0 +1,36 @@
+package com.sayjong.backend.lyric.dto.response;
+
+import com.sayjong.backend.lyric.domain.LyricLine;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LyricLineResponseDto {
+    private final Long lyricLineId;
+    private final Integer lineNo;
+    private final String originalText;
+    private final String textRomaja;
+    private final String textEng;
+    private final Long startTime;
+
+    @Builder
+    public LyricLineResponseDto(Long lyricLineId, Integer lineNo, String originalText, String textRomaja, String textEng, Long startTime) {
+        this.lyricLineId = lyricLineId;
+        this.lineNo = lineNo;
+        this.originalText = originalText;
+        this.textRomaja = textRomaja;
+        this.textEng = textEng;
+        this.startTime = startTime;
+    }
+
+    public static LyricLineResponseDto from(LyricLine lyricLine) {
+        return LyricLineResponseDto.builder()
+                .lyricLineId(lyricLine.getLyricLineId())
+                .lineNo(lyricLine.getLineNo())
+                .originalText(lyricLine.getOriginalText())
+                .textRomaja(lyricLine.getTextRomaja())
+                .textEng(lyricLine.getTextEng())
+                .startTime(lyricLine.getStartTime())
+                .build();
+    }
+}

--- a/src/main/java/com/sayjong/backend/lyric/repository/LyricLineRepository.java
+++ b/src/main/java/com/sayjong/backend/lyric/repository/LyricLineRepository.java
@@ -5,7 +5,11 @@ import org.springframework.stereotype.Repository;
 
 import com.sayjong.backend.lyric.domain.LyricLine;
 
+import java.util.List;
+
 @Repository
 public interface LyricLineRepository extends JpaRepository<LyricLine, Long> {
     boolean existsBySong_SongId(Integer songId);
+
+    List<LyricLine> findAllBySongSongIdOrderByLineNoAsc(Integer songId);
 }

--- a/src/main/java/com/sayjong/backend/lyric/repository/LyricLineRepository.java
+++ b/src/main/java/com/sayjong/backend/lyric/repository/LyricLineRepository.java
@@ -6,10 +6,15 @@ import org.springframework.stereotype.Repository;
 import com.sayjong.backend.lyric.domain.LyricLine;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface LyricLineRepository extends JpaRepository<LyricLine, Long> {
     boolean existsBySong_SongId(Integer songId);
 
+    // 노래 전체 소절 조회
     List<LyricLine> findAllBySongSongIdOrderByLineNoAsc(Integer songId);
+
+    // 노래 특정 소절 조회
+    Optional<LyricLine> findBySongSongIdAndLineNo(Integer songId, Integer lineNo);
 }

--- a/src/main/java/com/sayjong/backend/lyric/service/LyricLineService.java
+++ b/src/main/java/com/sayjong/backend/lyric/service/LyricLineService.java
@@ -20,6 +20,7 @@ public class LyricLineService {
     private final LyricLineRepository lyricLineRepository;
     private final SongRepository songRepository;
 
+    // 전체 소절 조회
     public List<LyricLineResponseDto> getLyricLinesBySongId(Integer songId) {
         if (!songRepository.existsById(songId)) {
             throw new EntityNotFoundException("Song not found with id: " + songId);
@@ -30,5 +31,14 @@ public class LyricLineService {
         return lyricLines.stream()
                 .map(LyricLineResponseDto::from)
                 .collect(Collectors.toList());
+    }
+
+    // 특정 소절 조회
+    public LyricLineResponseDto getLyricLineBySongIdAndLineNo(Integer songId, Integer lineNo) {
+        LyricLine lyricLine = lyricLineRepository.findBySongSongIdAndLineNo(songId, lineNo)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Lyric line not found for songId: " + songId + " and lineNo: " + lineNo
+                ));
+        return LyricLineResponseDto.from(lyricLine);
     }
 }

--- a/src/main/java/com/sayjong/backend/lyric/service/LyricLineService.java
+++ b/src/main/java/com/sayjong/backend/lyric/service/LyricLineService.java
@@ -1,0 +1,34 @@
+package com.sayjong.backend.lyric.service;
+
+import com.sayjong.backend.lyric.domain.LyricLine;
+import com.sayjong.backend.lyric.dto.response.LyricLineResponseDto;
+import com.sayjong.backend.lyric.repository.LyricLineRepository;
+import com.sayjong.backend.song.repository.SongRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LyricLineService {
+
+    private final LyricLineRepository lyricLineRepository;
+    private final SongRepository songRepository;
+
+    public List<LyricLineResponseDto> getLyricLinesBySongId(Integer songId) {
+        if (!songRepository.existsById(songId)) {
+            throw new EntityNotFoundException("Song not found with id: " + songId);
+        }
+
+        List<LyricLine> lyricLines = lyricLineRepository.findAllBySongSongIdOrderByLineNoAsc(songId);
+
+        return lyricLines.stream()
+                .map(LyricLineResponseDto::from)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 노래별 전체 소절 정보 가져오기
- 노래별 특정 소절 정보 가져오기

(nativeAudioUrl은 정보를 따로 데베에 저장해두지 않고 TTS로 바로 처리한다고 해서 우선 조회목록에서 제외시켰습니다.)

### 실행화면 캡처
**노래별 전체 소절 정보 가져오기**
<img width="978" height="805" alt="노래별 전체 소절정보" src="https://github.com/user-attachments/assets/cbf9cf3a-ddfa-4849-ba5c-4fa2852f6264" />

**노래별 특정 소절 정보 가져오기**
<img width="1009" height="769" alt="노래별 특정 소절정보" src="https://github.com/user-attachments/assets/7890193e-ddfa-4c84-a1b8-ac9012ba38ca" />


만약 해당 songId 혹은 lineNo에 해당하는 정보가 없다면 404에러와 함께 다음과 같은 메세지
<img width="1027" height="617" alt="lyricline에러" src="https://github.com/user-attachments/assets/5a43acde-f786-42c2-b447-d25b393c16e9" />

