### PR TITLE
Calibration 좌표 받아오는 거 구현

### DIFF
--- a/src/main/java/com/sayjong/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sayjong/backend/global/exception/GlobalExceptionHandler.java
@@ -48,4 +48,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(Map.of("error", e.getMessage()));
     }
+
+    // 다른 @ExceptionHandler 에서 잡지 못한 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleAllExceptions(Exception e) {
+        log.error("---Global Exception Handler: Unhandled Error Occurred---", e);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponseDto("서버 내부 오류가 발생했습니다."));
+    }
 }

--- a/src/main/java/com/sayjong/backend/userCalibration/controller/CalibrationController.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/controller/CalibrationController.java
@@ -1,0 +1,35 @@
+package com.sayjong.backend.userCalibration.controller;
+
+import com.sayjong.backend.userCalibration.dto.SaveCalibrationRequestDto;
+import com.sayjong.backend.userCalibration.service.CalibrationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/calibration")
+@RequiredArgsConstructor
+public class CalibrationController {
+
+    private final CalibrationService calibrationService;
+
+    // 로그인한 사용자의 캘리브레이션 좌표를 서버 데이터베이스에 저장하는 api
+    @PostMapping("/targets")
+    public ResponseEntity<Void> saveCalibrationTargets(
+            @RequestBody SaveCalibrationRequestDto requestDto,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).build(); // Unauthorized
+        }
+
+        calibrationService.saveCalibrationData(userDetails.getUsername(), requestDto);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sayjong/backend/userCalibration/domain/UserCalibration.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/domain/UserCalibration.java
@@ -28,7 +28,7 @@ public class UserCalibration {
     // calibration 좌표
     @Lob
     @Column(columnDefinition = "MEDIUMTEXT")
-    private String rawCalibrationJson; //
+    private String rawCalibrationJson;
 
     // 좌표가 저장된 시간 (UTC)
     private Instant calibratedAt;

--- a/src/main/java/com/sayjong/backend/userCalibration/domain/UserCalibration.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/domain/UserCalibration.java
@@ -1,0 +1,38 @@
+package com.sayjong.backend.userCalibration.domain;
+
+import com.sayjong.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@Setter
+public class UserCalibration {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true)
+    private User user;
+
+    // 정답 좌표
+    @Lob
+    @Column(columnDefinition = "MEDIUMTEXT")
+    private String vowelTargetsJson;
+
+    // calibration 좌표
+    @Lob
+    @Column(columnDefinition = "MEDIUMTEXT")
+    private String rawCalibrationJson; //
+
+    // 좌표가 저장된 시간 (UTC)
+    private Instant calibratedAt;
+
+    // 연동 후 데이터(json) 형식이 바뀌었을 때 저장되어 있는 데이터가 어떤 형식 기준으로 저장된 것인지 확인할 수 있도록 넣어줌
+    private String dataVersion;
+}

--- a/src/main/java/com/sayjong/backend/userCalibration/dto/LandmarkDto.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/dto/LandmarkDto.java
@@ -1,0 +1,12 @@
+package com.sayjong.backend.userCalibration.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LandmarkDto {
+    private double x;
+    private double y;
+    private double z;
+}

--- a/src/main/java/com/sayjong/backend/userCalibration/dto/PrecomputedTargetsDto.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/dto/PrecomputedTargetsDto.java
@@ -1,0 +1,14 @@
+package com.sayjong.backend.userCalibration.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class PrecomputedTargetsDto {
+    private String calibratedAt;
+    private String version;
+    private Map<String, VowelTargetDto> vowels;
+}

--- a/src/main/java/com/sayjong/backend/userCalibration/dto/RawFrameDto.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/dto/RawFrameDto.java
@@ -1,0 +1,14 @@
+package com.sayjong.backend.userCalibration.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+public class RawFrameDto {
+    private Map<String, List<Double>> landmarks;
+    private Map<String, Double> blendshapes;
+}

--- a/src/main/java/com/sayjong/backend/userCalibration/dto/SaveCalibrationRequestDto.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/dto/SaveCalibrationRequestDto.java
@@ -1,0 +1,13 @@
+package com.sayjong.backend.userCalibration.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class SaveCalibrationRequestDto {
+    private PrecomputedTargetsDto precomputedData;
+    private Map<String, RawFrameDto> rawData;
+}

--- a/src/main/java/com/sayjong/backend/userCalibration/dto/VowelTargetDto.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/dto/VowelTargetDto.java
@@ -1,0 +1,13 @@
+package com.sayjong.backend.userCalibration.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class VowelTargetDto {
+    private Map<String, LandmarkDto> landmarks;
+    private Map<String, Double> blendshapes;
+}

--- a/src/main/java/com/sayjong/backend/userCalibration/repository/UserCalibrationRepository.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/repository/UserCalibrationRepository.java
@@ -1,0 +1,12 @@
+package com.sayjong.backend.userCalibration.repository;
+
+import com.sayjong.backend.user.domain.User;
+import com.sayjong.backend.userCalibration.domain.UserCalibration;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserCalibrationRepository extends JpaRepository<UserCalibration, Long> {
+    // 사용자로 캘리브레이션 데이터 찾기
+    Optional<UserCalibration> findByUser(User user);
+}

--- a/src/main/java/com/sayjong/backend/userCalibration/service/CalibrationService.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/service/CalibrationService.java
@@ -1,0 +1,73 @@
+package com.sayjong.backend.userCalibration.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sayjong.backend.user.domain.User;
+import com.sayjong.backend.user.repository.UserRepository;
+import com.sayjong.backend.userCalibration.domain.UserCalibration;
+import com.sayjong.backend.userCalibration.dto.PrecomputedTargetsDto;
+import com.sayjong.backend.userCalibration.dto.RawFrameDto;
+import com.sayjong.backend.userCalibration.dto.SaveCalibrationRequestDto;
+import com.sayjong.backend.userCalibration.repository.UserCalibrationRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CalibrationService {
+
+    private final UserCalibrationRepository calibrationRepo;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void saveCalibrationData(String loginId, SaveCalibrationRequestDto requestDto) {
+
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        try {
+            // DTO 에서 두 데이터를 분리
+            PrecomputedTargetsDto precomputedDto = requestDto.getPrecomputedData();
+            Map<String, RawFrameDto> rawDataMap = requestDto.getRawData();
+
+            if (precomputedDto == null) {
+                throw new IllegalArgumentException("'precomputedData'가 null입니다. JSON 키 이름을 확인하세요.");
+            }
+            if (rawDataMap == null) {
+                throw new IllegalArgumentException("'rawData'가 null입니다. JSON 키 이름을 확인하세요.");
+            }
+            if (precomputedDto.getCalibratedAt() == null) {
+                throw new IllegalArgumentException("'calibratedAt' 필드가 null입니다. DTO 매핑을 확인하세요.");
+            }
+
+            // 정답좌표 데이터를 JSON 문자열로 변환
+            String vowelsJson = objectMapper.writeValueAsString(precomputedDto.getVowels());
+
+            // calibtration 데이터를 JSON 문자열로 변환
+            String rawJson = objectMapper.writeValueAsString(rawDataMap);
+
+            // 기존 데이터가 있는지 확인
+            UserCalibration calibration = calibrationRepo.findByUser(user)
+                    .orElse(new UserCalibration());
+
+            // 데이터 설정
+            calibration.setUser(user);
+            calibration.setVowelTargetsJson(vowelsJson); // 정답좌표
+            calibration.setRawCalibrationJson(rawJson);  // calibration 좌표
+
+            calibration.setCalibratedAt(Instant.parse(precomputedDto.getCalibratedAt()));
+            calibration.setDataVersion(precomputedDto.getVersion());
+
+            calibrationRepo.save(calibration);
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("캘리브레이션 데이터 JSON 직렬화에 실패했습니다.", e);
+        }
+    }
+}


### PR DESCRIPTION
# Pull requests
### 작업 내용
- 캘리브레이션 좌표를 받아서 저장할 **UserCalibtration 엔티티** 추가 
 -정답좌표는 vowelTargetsJson에, calibration한 원본 좌표는 rawCalibrationJson에 저장 합니다(파일이 생각보다 커서 TEXT가 아닌 MEDIUMTEXT를 사용했어요!)
 -버튼을 눌렀을 때 데이터베이스 안의 값들이 잘 없데이트가 되는지 확인하기 쉽도록 좌표가 저장된 시간도 기록에 남겼습니다.
 -혹시라도 받게 되는 json의 형식이 달라질 경우를 대비하여 dataVersion을 남겨놨습니다. (기존에 저장해놨던 데이터와 프론트에서 새로 설정한 구조가 다르다면 에러가 발생할 수 있으므로 버전이 맞지 않는 경우에는 캡처를 다시해서 새로 데이터를 저장해주어야 함)
 - 로그인한 사용자의 캘리브레이션 좌표와, 이를 통해 추출된 정답 **좌표를 받아와 서버 데이터베이스에 저장하는 api를 구현: /api/calibration/targets**

### 실행화면 캡쳐
(임의로 로컬에서 연동 후 테스트 해봤을 때의 결과물)

**웹화면**: 프론트엔드 화면에서 calibration좌표를 캡처해서 다운로드 버튼을 누르면, api가 호출됩니다.
 정상적으로 백엔드로 넘어가 데이터베이스에 저장이 되었다면, 아래 화면과 같이 정상적으로 저장되었다는 메세지가 뜹니다.
<img width="588" height="253" alt="image" src="https://github.com/user-attachments/assets/3a6157ed-083e-4d13-88cd-453c0257043b" />



**데이터베이스**: 이후 데이터베이스에 들어가서 확인해보면, 좌표값들이 json의 형식으로 잘 저장 되어 있는 모습을 볼 수 있습니다.

<img width="1059" height="458" alt="프-백 연동 json" src="https://github.com/user-attachments/assets/4bb8248d-f573-46cf-8591-d914b77c8b0a" />
<img width="857" height="952" alt="raw_calibration_json(칼리브레이션 좌표)" src="https://github.com/user-attachments/assets/d65a5178-dd92-4b21-b6cd-0d2f769eb1fe" />
<img width="971" height="946" alt="vowel_targets_json(정답좌표)" src="https://github.com/user-attachments/assets/4b3eb519-b59c-4a8c-84fe-790720f4273b" />
