### PR TITLE
Lyric 관련 responseDto에 nativeAudioUrl 추가

### DIFF
--- a/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineResponseDto.java
+++ b/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineResponseDto.java
@@ -11,15 +11,17 @@ public class LyricLineResponseDto {
     private final String originalText;
     private final String textRomaja;
     private final String textEng;
+    private String nativeAudioUrl;
     private final Long startTime;
 
     @Builder
-    public LyricLineResponseDto(Long lyricLineId, Integer lineNo, String originalText, String textRomaja, String textEng, Long startTime) {
+    public LyricLineResponseDto(Long lyricLineId, Integer lineNo, String originalText, String textRomaja, String textEng, String nativeAudioUrl, Long startTime) {
         this.lyricLineId = lyricLineId;
         this.lineNo = lineNo;
         this.originalText = originalText;
         this.textRomaja = textRomaja;
         this.textEng = textEng;
+        this.nativeAudioUrl = nativeAudioUrl;
         this.startTime = startTime;
     }
 
@@ -30,6 +32,7 @@ public class LyricLineResponseDto {
                 .originalText(lyricLine.getOriginalText())
                 .textRomaja(lyricLine.getTextRomaja())
                 .textEng(lyricLine.getTextEng())
+                .nativeAudioUrl(lyricLine.getNativeAudioUrl())
                 .startTime(lyricLine.getStartTime())
                 .build();
     }

--- a/src/main/java/com/sayjong/backend/lyric/dto/response/LyricSyllableResponseDto.java
+++ b/src/main/java/com/sayjong/backend/lyric/dto/response/LyricSyllableResponseDto.java
@@ -11,13 +11,15 @@ public class LyricSyllableResponseDto {
     private final Integer sylNo;
     private final String textKor;
     private final String textRomaja;
+    private String nativeAudioUrl;
 
     @Builder
-    public LyricSyllableResponseDto(Long lyricSyllableId, Integer sylNo, String textKor, String textRomaja) {
+    public LyricSyllableResponseDto(Long lyricSyllableId, Integer sylNo, String textKor, String textRomaja, String nativeAudioUrl) {
         this.lyricSyllableId = lyricSyllableId;
         this.sylNo = sylNo;
         this.textKor = textKor;
         this.textRomaja = textRomaja;
+        this.nativeAudioUrl = nativeAudioUrl;
     }
 
     public static LyricSyllableResponseDto from(LyricSyllable syllable) {
@@ -26,6 +28,7 @@ public class LyricSyllableResponseDto {
                 .sylNo(syllable.getSylNo())
                 .textKor(syllable.getTextKor())
                 .textRomaja(syllable.getTextRomaja())
+                .nativeAudioUrl(syllable.getNativeAudioUrl())
                 .build();
     }
 }


### PR DESCRIPTION
# Pull requests
### 작업 내용
- 노래 정보 관련 API response에 nativeAudioUrl (TTS) 추가

### 실행화면 캡쳐
**노래별 전체 소절 정보**
<img width="639" height="614" alt="노래별 전체 소절 정보" src="https://github.com/user-attachments/assets/6fc1e2c0-298f-4ce8-b525-e9550fd8bb45" />

**노래별 특정 소절 정보**
<img width="630" height="566" alt="노래별 특정 소절 정보" src="https://github.com/user-attachments/assets/471d366d-8d88-4a6a-af8c-db812ba82acb" />

**소절별 음절 정보**
<img width="630" height="566" alt="소절별 음절정보" src="https://github.com/user-attachments/assets/7b21b80c-a060-46b4-86bc-d182ee0c899b" />
