### PR TITLE
feat(calibration): 데베에 저장된 좌표json 프론트에 전달

### DIFF
--- a/src/main/java/com/sayjong/backend/userCalibration/controller/CalibrationController.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/controller/CalibrationController.java
@@ -1,15 +1,14 @@
 package com.sayjong.backend.userCalibration.controller;
 
+import com.sayjong.backend.userCalibration.dto.CalibrationDataResponseDto;
 import com.sayjong.backend.userCalibration.dto.SaveCalibrationRequestDto;
 import com.sayjong.backend.userCalibration.service.CalibrationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/calibration")
@@ -18,9 +17,9 @@ public class CalibrationController {
 
     private final CalibrationService calibrationService;
 
-    // 로그인한 사용자의 캘리브레이션 좌표를 서버 데이터베이스에 저장하는 api
+    // 로그인한 사용자의 캘리브레이션 좌표를 서버 데이터베이스에 저장하는 api + 프론트에 반환
     @PostMapping("/targets")
-    public ResponseEntity<Void> saveCalibrationTargets(
+    public ResponseEntity<CalibrationDataResponseDto> saveCalibrationTargets(
             @RequestBody SaveCalibrationRequestDto requestDto,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
@@ -28,8 +27,20 @@ public class CalibrationController {
             return ResponseEntity.status(401).build(); // Unauthorized
         }
 
-        calibrationService.saveCalibrationData(userDetails.getUsername(), requestDto);
+        CalibrationDataResponseDto responseDto = calibrationService.saveCalibrationData(
+                userDetails.getUsername(),
+                requestDto
+        );
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(responseDto);
+    }
+    // 로그인한 사용자의 캘리브레이션 좌표를 조회하는 api (존재한다면 반환)
+    @GetMapping("my-data")
+    public ResponseEntity<CalibrationDataResponseDto> getMyCalibrationData(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        CalibrationDataResponseDto responseDto = calibrationService.getCalibrationData(userDetails.getUsername());
+
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/sayjong/backend/userCalibration/dto/CalibrationDataResponseDto.java
+++ b/src/main/java/com/sayjong/backend/userCalibration/dto/CalibrationDataResponseDto.java
@@ -1,0 +1,16 @@
+package com.sayjong.backend.userCalibration.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CalibrationDataResponseDto {
+
+    private final String vowelTargetsJson; // target_vowels.json이 될 데이터
+
+    private final String rawCalibrationJson; // vowel_calibration.json이 될 데이터
+
+    public CalibrationDataResponseDto(String vowelTargetsJson, String rawCalibrationJson) {
+        this.vowelTargetsJson = vowelTargetsJson;
+        this.rawCalibrationJson = rawCalibrationJson;
+    }
+}


### PR DESCRIPTION
## 작업한 내용
데베에 저장된 좌표를 프론트엔드에 전달해주기 위한 작업을 함
- 기존 /api/calibration/targets 를 호출하면, DB에 저장될 뿐만 아니라 저장된 JSON 2개를 즉시 응답으로 돌려줄 수 있도록 수정
- 로그인 시 현재 로그인한 사용자의 JSON 2개를 받아올 수 있는 api 구현 (/api/calibration/my-data 추가)

