### PR TITLE
Lyric 관련 responseDto에 syllableTimings 추가

### DIFF
--- a/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineResponseDto.java
+++ b/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineResponseDto.java
@@ -13,9 +13,12 @@ public class LyricLineResponseDto {
     private final String textEng;
     private String nativeAudioUrl;
     private final Long startTime;
+    private String syllableTimings;
 
     @Builder
-    public LyricLineResponseDto(Long lyricLineId, Integer lineNo, String originalText, String textRomaja, String textEng, String nativeAudioUrl, Long startTime) {
+    public LyricLineResponseDto(Long lyricLineId, Integer lineNo,
+            String originalText, String textRomaja, String textEng,
+            String nativeAudioUrl, Long startTime, String syllableTimings) {
         this.lyricLineId = lyricLineId;
         this.lineNo = lineNo;
         this.originalText = originalText;
@@ -23,6 +26,7 @@ public class LyricLineResponseDto {
         this.textEng = textEng;
         this.nativeAudioUrl = nativeAudioUrl;
         this.startTime = startTime;
+        this.syllableTimings = syllableTimings;
     }
 
     public static LyricLineResponseDto from(LyricLine lyricLine) {
@@ -34,6 +38,7 @@ public class LyricLineResponseDto {
                 .textEng(lyricLine.getTextEng())
                 .nativeAudioUrl(lyricLine.getNativeAudioUrl())
                 .startTime(lyricLine.getStartTime())
+                .syllableTimings(lyricLine.getSyllableTimings())
                 .build();
     }
 }


### PR DESCRIPTION
노래 정보 관련 API response에 syllableTimings (TTS) 추가 간단히 했어요~

<img width="949" height="493" alt="image" src="https://github.com/user-attachments/assets/88b85076-0b07-4c42-81ab-affb8354026e" />
<img width="944" height="744" alt="image" src="https://github.com/user-attachments/assets/6ea97ec4-ea49-495c-a867-15d959496f25" />
