### PR TITLE
음절 정보 조회 api 수정

### DIFF
--- a/src/main/java/com/sayjong/backend/lyric/controller/LyricLineController.java
+++ b/src/main/java/com/sayjong/backend/lyric/controller/LyricLineController.java
@@ -5,6 +5,7 @@ import com.sayjong.backend.lyric.dto.response.LyricSyllableResponseDto;
 import com.sayjong.backend.lyric.service.LyricLineService;
 import com.sayjong.backend.lyric.service.LyricSyllableService;
 import com.sayjong.backend.song.dto.SongLyricResponseDto;
+import com.sayjong.backend.song.dto.SongLyricsWithSyllablesDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -42,17 +43,13 @@ public class LyricLineController {
         return ResponseEntity.ok(lyricLineDto);
     }
 
-    // 특정 노래의 소절별 음절 정보 가져오기
-    @GetMapping("/{songId}/lyriclines/{lineNo}/syllables/{sylNo}")
+    // 노래별 전체 음절 정보
+    @GetMapping("/{songId}/lyricSyllables")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<LyricSyllableResponseDto> getSpecificSyllable(
-            @PathVariable("songId") Integer songId,
-            @PathVariable("lineNo") Integer lineNo,
-            @PathVariable("sylNo") Integer sylNo
+    public ResponseEntity<SongLyricsWithSyllablesDto> getSongLyricsWithSyllables(
+            @PathVariable Integer songId
     ) {
-        LyricSyllableResponseDto syllableDto = lyricSyllableService
-                .getSpecificSyllable(songId, lineNo, sylNo);
-
-        return ResponseEntity.ok(syllableDto);
+        SongLyricsWithSyllablesDto response = lyricLineService.getSongLyricsWithSyllables(songId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineWithSyllablesDto.java
+++ b/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineWithSyllablesDto.java
@@ -1,0 +1,44 @@
+package com.sayjong.backend.lyric.dto.response;
+
+import com.sayjong.backend.lyric.domain.LyricLine;
+import com.sayjong.backend.lyric.domain.LyricSyllable;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class LyricLineWithSyllablesDto {
+    private final Long lyricLineId;
+    private final Integer lineNo;
+    private final String originalText;
+
+    // 음절 리스트 포함
+    private final List<LyricSyllableResponseDto> syllables;
+
+    @Builder
+    public LyricLineWithSyllablesDto(Long lyricLineId, Integer lineNo, String originalText,
+                                     String textRomaja, String textEng, String nativeAudioUrl,
+                                     Long startTime, String syllableTimings,
+                                     List<LyricSyllableResponseDto> syllables) {
+        this.lyricLineId = lyricLineId;
+        this.lineNo = lineNo;
+        this.originalText = originalText;
+        this.syllables = syllables;
+    }
+
+    public static LyricLineWithSyllablesDto from(LyricLine line, List<LyricSyllable> syllables) {
+
+        List<LyricSyllableResponseDto> syllableDtos = syllables.stream()
+                .map(LyricSyllableResponseDto::from)
+                .collect(Collectors.toList());
+
+        return LyricLineWithSyllablesDto.builder()
+                .lyricLineId(line.getLyricLineId())
+                .lineNo(line.getLineNo())
+                .originalText(line.getOriginalText())
+                .syllables(syllableDtos)
+                .build();
+    }
+}

--- a/src/main/java/com/sayjong/backend/lyric/dto/response/LyricSyllableResponseDto.java
+++ b/src/main/java/com/sayjong/backend/lyric/dto/response/LyricSyllableResponseDto.java
@@ -6,16 +6,13 @@ import lombok.Getter;
 
 @Getter
 public class LyricSyllableResponseDto {
-
-    private final Long lyricSyllableId;
     private final Integer sylNo;
     private final String textKor;
     private final String textRomaja;
-    private String nativeAudioUrl;
+    private final String nativeAudioUrl;
 
     @Builder
-    public LyricSyllableResponseDto(Long lyricSyllableId, Integer sylNo, String textKor, String textRomaja, String nativeAudioUrl) {
-        this.lyricSyllableId = lyricSyllableId;
+    public LyricSyllableResponseDto(Integer sylNo, String textKor, String textRomaja, String nativeAudioUrl) {
         this.sylNo = sylNo;
         this.textKor = textKor;
         this.textRomaja = textRomaja;
@@ -24,7 +21,6 @@ public class LyricSyllableResponseDto {
 
     public static LyricSyllableResponseDto from(LyricSyllable syllable) {
         return LyricSyllableResponseDto.builder()
-                .lyricSyllableId(syllable.getLyricSyllableId())
                 .sylNo(syllable.getSylNo())
                 .textKor(syllable.getTextKor())
                 .textRomaja(syllable.getTextRomaja())

--- a/src/main/java/com/sayjong/backend/lyric/repository/LyricLineRepository.java
+++ b/src/main/java/com/sayjong/backend/lyric/repository/LyricLineRepository.java
@@ -20,4 +20,10 @@ public interface LyricLineRepository extends JpaRepository<LyricLine, Long> {
 
     // 노래 특정 소절 조회
     Optional<LyricLine> findBySongSongIdAndLineNo(Integer songId, Integer lineNo);
+
+    // 특정 노래의 모든 소절을 lineNo 순으로 조회
+    @Query("SELECT ll FROM LyricLine ll " +
+            "WHERE ll.song.songId = :songId " +
+            "ORDER BY ll.lineNo ASC")
+    List<LyricLine> findAllBySongIdOrderByLineNoAsc(@Param("songId") Integer songId);
 }

--- a/src/main/java/com/sayjong/backend/lyric/repository/LyricSyllableRepository.java
+++ b/src/main/java/com/sayjong/backend/lyric/repository/LyricSyllableRepository.java
@@ -1,10 +1,13 @@
 package com.sayjong.backend.lyric.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.sayjong.backend.lyric.domain.LyricSyllable;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +18,10 @@ public interface LyricSyllableRepository
     Optional<LyricSyllable> findByLyricLineSongSongIdAndLyricLineLineNoAndSylNo(
             Integer songId, Integer lineNo, Integer sylNo
     );
+
+    // 소절에 속한 모든 음절을 한 번에 조회
+    @Query("SELECT s FROM LyricSyllable s " +
+            "WHERE s.lyricLine.lyricLineId IN :lineIds " +
+            "ORDER BY s.sylNo ASC")
+    List<LyricSyllable> findAllByLyricLineIds(@Param("lineIds") List<Long> lineIds);
 }

--- a/src/main/java/com/sayjong/backend/song/dto/SongLyricsWithSyllablesDto.java
+++ b/src/main/java/com/sayjong/backend/song/dto/SongLyricsWithSyllablesDto.java
@@ -1,0 +1,23 @@
+package com.sayjong.backend.song.dto;
+
+import com.sayjong.backend.lyric.dto.response.LyricLineWithSyllablesDto;
+import com.sayjong.backend.song.domain.Song;
+
+import java.util.List;
+
+public record SongLyricsWithSyllablesDto(
+        Integer songId,
+        String title,
+        String singer,
+        List<LyricLineWithSyllablesDto> lyrics
+) {
+
+    public static SongLyricsWithSyllablesDto from(Song song, List<LyricLineWithSyllablesDto> lyrics) {
+        return new SongLyricsWithSyllablesDto(
+                song.getSongId(),
+                song.getTitle(),
+                song.getSinger(),
+                lyrics
+        );
+    }
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용

>  기존의 소절별 음절 정보 가져오기 api(`/api/songs/{songId}/lyriclines/{lineNo}/syllables/{sylNo}`) 삭제 (너무 비효율적)

- **노래별 전체 음절 정보 조회 api 구현**: `/api/songs/{songId}/lyricSyllables`
-songId만을 통해서 해당 노래의 전체 음절 정보를 받아 올 수 있도록 함
-설계된 ui 화면에서 필요한 것들만 응답하도록 dto 재설계
-소절을 기준으로 음절이 그룹화된 계층 구조로 반환됨
-음절 데이터가 없는 소절은 응답에서 제외하도록 필터링 (즉, 영어 가사는 제외)

### 실행화면 캡처
응답은 json의 형식이나, 구조를 한눈에 파악하기 쉽도록 preview 화면 캡처했음
<img width="1146" height="848" alt="스크린샷 2025-11-12 오전 12 56 59" src="https://github.com/user-attachments/assets/0464b6c9-7874-48dd-9f01-fca41a27c8d5" />
