### PR TITLE
refactor(lyric): 영어 포함 소절 전체가 return 안되는 오류 수정

### DIFF
--- a/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineResponseDto.java
+++ b/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineResponseDto.java
@@ -1,6 +1,7 @@
 package com.sayjong.backend.lyric.dto.response;
 
 import com.sayjong.backend.lyric.domain.LyricLine;
+import com.sayjong.backend.lyric.service.LyricLineService;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -30,10 +31,14 @@ public class LyricLineResponseDto {
     }
 
     public static LyricLineResponseDto from(LyricLine lyricLine) {
+
+        // 한국어 가사만 나오도록 필터링
+        String cleanedText = LyricLineService.cleanKoreanText(lyricLine.getOriginalText());
+
         return LyricLineResponseDto.builder()
                 .lyricLineId(lyricLine.getLyricLineId())
                 .lineNo(lyricLine.getLineNo())
-                .originalText(lyricLine.getOriginalText())
+                .originalText(cleanedText)
                 .textRomaja(lyricLine.getTextRomaja())
                 .textEng(lyricLine.getTextEng())
                 .nativeAudioUrl(lyricLine.getNativeAudioUrl())

--- a/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineWithSyllablesDto.java
+++ b/src/main/java/com/sayjong/backend/lyric/dto/response/LyricLineWithSyllablesDto.java
@@ -2,6 +2,7 @@ package com.sayjong.backend.lyric.dto.response;
 
 import com.sayjong.backend.lyric.domain.LyricLine;
 import com.sayjong.backend.lyric.domain.LyricSyllable;
+import com.sayjong.backend.lyric.service.LyricLineService;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -30,6 +31,9 @@ public class LyricLineWithSyllablesDto {
 
     public static LyricLineWithSyllablesDto from(LyricLine line, List<LyricSyllable> syllables) {
 
+        // 한국어 가사만 나오도록 필터링
+        String cleanedText = LyricLineService.cleanKoreanText(line.getOriginalText());
+
         List<LyricSyllableResponseDto> syllableDtos = syllables.stream()
                 .map(LyricSyllableResponseDto::from)
                 .collect(Collectors.toList());
@@ -37,7 +41,7 @@ public class LyricLineWithSyllablesDto {
         return LyricLineWithSyllablesDto.builder()
                 .lyricLineId(line.getLyricLineId())
                 .lineNo(line.getLineNo())
-                .originalText(line.getOriginalText())
+                .originalText(cleanedText)
                 .syllables(syllableDtos)
                 .build();
     }


### PR DESCRIPTION
어제 머지 시킨 로직이 음절연습, 소절연습 구간에서 영어 가사만 제외시키지 않고 영어가 포함된 소절 자체를 제거시키는 오류가 있어서 수정하였습니다~