### PR TITLE
feat(scoreHistory): 특정 노래에 대한 점수기록 조회 구현

### DIFF
--- a/src/main/java/com/sayjong/backend/training/controller/ScoreHistoryController.java
+++ b/src/main/java/com/sayjong/backend/training/controller/ScoreHistoryController.java
@@ -1,0 +1,36 @@
+package com.sayjong.backend.training.controller;
+
+import com.sayjong.backend.training.dto.response.ScoreHistoryResponseDto;
+import com.sayjong.backend.training.service.ScoreHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users/me")
+@RequiredArgsConstructor
+public class ScoreHistoryController {
+
+    private final ScoreHistoryService scoreHistoryService;
+
+    // 특정 노래에 대한 점수 기록 조회
+    @GetMapping("/session/{sessionId}/scoreHistory")
+    public ResponseEntity<List<ScoreHistoryResponseDto>> getMyScoreHistoryForSession(
+            @PathVariable Integer sessionId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String username = userDetails.getUsername();
+
+        List<ScoreHistoryResponseDto> historyList = scoreHistoryService
+                .getScoreHistoryForSessionByUsername(username, sessionId);
+
+        return ResponseEntity.ok(historyList);
+    }
+}

--- a/src/main/java/com/sayjong/backend/training/dto/response/ScoreHistoryResponseDto.java
+++ b/src/main/java/com/sayjong/backend/training/dto/response/ScoreHistoryResponseDto.java
@@ -1,0 +1,34 @@
+package com.sayjong.backend.training.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sayjong.backend.training.domain.ScoreHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ScoreHistoryResponseDto {
+
+    private Integer id;
+    private Integer score;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime scoredAt;
+
+    private Integer userId;
+    private Integer songId;
+    private Integer sessionId;
+
+    public static ScoreHistoryResponseDto from(ScoreHistory history) {
+        return ScoreHistoryResponseDto.builder()
+                .id(history.getId())
+                .score(history.getScore())
+                .scoredAt(history.getScoredAt())
+                .userId(history.getUser().getUserId())
+                .songId(history.getSong().getSongId())
+                .sessionId(history.getSession().getSessionId())
+                .build();
+    }
+}

--- a/src/main/java/com/sayjong/backend/training/repository/ScoreHistoryRepository.java
+++ b/src/main/java/com/sayjong/backend/training/repository/ScoreHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.sayjong.backend.training.repository;
+
+import com.sayjong.backend.training.domain.ScoreHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ScoreHistoryRepository extends JpaRepository<ScoreHistory, Integer> {
+
+    // 사용자의 특정 세션에 대한 모든 점수 기록을 조회
+    List<ScoreHistory> findByUserUserIdAndSessionSessionIdOrderByScoredAtDesc(Integer userId, Integer sessionId);
+}

--- a/src/main/java/com/sayjong/backend/training/service/ScoreHistoryService.java
+++ b/src/main/java/com/sayjong/backend/training/service/ScoreHistoryService.java
@@ -1,0 +1,36 @@
+package com.sayjong.backend.training.service;
+
+import com.sayjong.backend.training.domain.ScoreHistory;
+import com.sayjong.backend.training.dto.response.ScoreHistoryResponseDto;
+import com.sayjong.backend.training.repository.ScoreHistoryRepository;
+import com.sayjong.backend.user.domain.User;
+import com.sayjong.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScoreHistoryService {
+
+    private final UserRepository userRepository;
+    private final ScoreHistoryRepository scoreHistoryRepository;
+
+    public List<ScoreHistoryResponseDto> getScoreHistoryForSessionByUsername(String username, Integer sessionId) {
+
+        User user = userRepository.findByLoginId(username)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        List<ScoreHistory> histories = scoreHistoryRepository
+                .findByUserUserIdAndSessionSessionIdOrderByScoredAtDesc(user.getUserId(), sessionId);
+
+        return histories.stream()
+                .map(ScoreHistoryResponseDto::from)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### 작업한 내용
특정 노래에 대한 점수기록 조회 구현 ` /api/users/me/session/{sessionId}/scoreHistory`
(데이터베이스에는 일단 임의로 값을 넣어 테스트 해봤어요)

### 실행화면 캡처
<img width="721" height="639" alt="스크린샷 2025-11-15 오후 11 30 18" src="https://github.com/user-attachments/assets/90d55e88-f527-4c72-b909-1dd1fc5ad3ef" />
