### PR TITLE
feat(scoreHistory): 노래방 점수 저장 api 구현

### DIFF
--- a/src/main/java/com/sayjong/backend/training/controller/ScoreHistoryController.java
+++ b/src/main/java/com/sayjong/backend/training/controller/ScoreHistoryController.java
@@ -1,15 +1,15 @@
 package com.sayjong.backend.training.controller;
 
+import com.sayjong.backend.training.dto.request.ScoreHistoryRequestDto;
 import com.sayjong.backend.training.dto.response.ScoreHistoryResponseDto;
+import com.sayjong.backend.training.dto.response.ScoreResponseDto;
 import com.sayjong.backend.training.service.ScoreHistoryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -19,6 +19,21 @@ import java.util.List;
 public class ScoreHistoryController {
 
     private final ScoreHistoryService scoreHistoryService;
+
+    // 노래방 점수 저장
+    @PostMapping("/songs/{songId}/scores")
+    public ResponseEntity<ScoreResponseDto> createScoreRecord(
+            @PathVariable("songId") Integer songId,
+            @RequestBody ScoreHistoryRequestDto.CreateScoreRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+
+        String username = userDetails.getUsername();
+
+        ScoreResponseDto response = scoreHistoryService.saveScore(username, songId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 
     // 특정 노래에 대한 점수 기록 조회
     @GetMapping("/session/{sessionId}/scoreHistory")

--- a/src/main/java/com/sayjong/backend/training/domain/TrainingSession.java
+++ b/src/main/java/com/sayjong/backend/training/domain/TrainingSession.java
@@ -38,4 +38,14 @@ public class TrainingSession {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "song_id", nullable = false) // 노래식별자
     private Song song;
+
+    // 점수 업데이트
+    public void updateScores(int newScore) {
+        this.recentScore = newScore;
+
+        // 최고 점수가 비어있거나, 새 점수가 더 높으면 최고 점수 갱신
+        if (this.bestScore == null || newScore > this.bestScore) {
+            this.bestScore = newScore;
+        }
+    }
 }

--- a/src/main/java/com/sayjong/backend/training/dto/request/ScoreHistoryRequestDto.java
+++ b/src/main/java/com/sayjong/backend/training/dto/request/ScoreHistoryRequestDto.java
@@ -1,0 +1,13 @@
+package com.sayjong.backend.training.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ScoreHistoryRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateScoreRequest {
+        private Integer score;
+    }
+}

--- a/src/main/java/com/sayjong/backend/training/dto/response/ScoreResponseDto.java
+++ b/src/main/java/com/sayjong/backend/training/dto/response/ScoreResponseDto.java
@@ -1,0 +1,23 @@
+package com.sayjong.backend.training.dto.response;
+
+import com.sayjong.backend.training.domain.ScoreHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ScoreResponseDto {
+    private Integer id;
+    private Integer score;
+    private LocalDateTime scoredAt;
+
+    public static ScoreResponseDto from(ScoreHistory entity) {
+        return ScoreResponseDto.builder()
+                .id(entity.getId())
+                .score(entity.getScore())
+                .scoredAt(entity.getScoredAt())
+                .build();
+    }
+}

--- a/src/main/java/com/sayjong/backend/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/sayjong/backend/training/repository/TrainingSessionRepository.java
@@ -1,0 +1,12 @@
+package com.sayjong.backend.training.repository;
+
+import com.sayjong.backend.training.domain.TrainingSession;
+import com.sayjong.backend.song.domain.Song;
+import com.sayjong.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface TrainingSessionRepository extends JpaRepository<TrainingSession, Integer> {
+
+    Optional<TrainingSession> findByUserAndSong(User user, Song song);
+}


### PR DESCRIPTION
# Pull requests
### 작업 내용
- 프론트엔드에서 도출된 노래방 점수를 받아와서 데이터베이스에 저장하기 위해 노래방 점수 저장 api 추가했어요~
: `/api/users/me/songs/{songId}/scores`
- ScoreHistroy 데이터베이스에 저장하기에 앞서 TrainSession 데이터베이스를 조회 후, 사용자가 처음 연습한 노래라면 TrainSession의 데이터베이스를 먼저 갱신해줍니다.

### 실행화면 캡처
<img width="695" height="448" alt="스크린샷 2025-11-18 오후 5 37 10" src="https://github.com/user-attachments/assets/a6983ff5-5f59-46a0-9818-d3e909540263" />

**🔽아래와 같이 현재 한국 시간으로 데이터베이스에 잘 저장되는 것을 확인할 수 있음**

<img width="695" height="296" alt="스크린샷 2025-11-18 오후 5 37 42" src="https://github.com/user-attachments/assets/780d25f8-6fd8-480c-b314-e561379571ff" />
<img width="695" height="296" alt="스크린샷 2025-11-18 오후 5 37 49" src="https://github.com/user-attachments/assets/fc383132-0936-409d-930b-53e35612b18a" />
