### PR TITLE
feat(trainigSession): 학습 내용 조회 api 구현

### DIFF
--- a/src/main/java/com/sayjong/backend/training/controller/TrainingSessionController.java
+++ b/src/main/java/com/sayjong/backend/training/controller/TrainingSessionController.java
@@ -1,0 +1,33 @@
+package com.sayjong.backend.training.controller;
+
+import com.sayjong.backend.training.dto.response.TrainingSessionResponseDto;
+import com.sayjong.backend.training.service.TrainingSessionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users/me/training-sessions")
+@RequiredArgsConstructor
+public class TrainingSessionController {
+
+    private final TrainingSessionService trainingSessionService;
+
+    // 학습 내역 조회
+    @GetMapping
+    public ResponseEntity<List<TrainingSessionResponseDto>> getMySessions(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String username = userDetails.getUsername();
+
+        List<TrainingSessionResponseDto> response = trainingSessionService.getMySessions(username);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/sayjong/backend/training/domain/TrainingSession.java
+++ b/src/main/java/com/sayjong/backend/training/domain/TrainingSession.java
@@ -26,6 +26,9 @@ public class TrainingSession {
     private Integer sessionId; // 학습목록ID(PK)
 
     @Column
+    private Integer averageScore; // 평균 점수
+
+    @Column
     private Integer bestScore; // best 점수
 
     @Column
@@ -38,6 +41,9 @@ public class TrainingSession {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "song_id", nullable = false) // 노래식별자
     private Song song;
+
+    @Column
+    private LocalDateTime lastPlayedAt; // 최근에 학습한 노래 순으로 화면에 띄워주기 위해 추가
 
     // 점수 업데이트
     public void updateScores(int newScore) {

--- a/src/main/java/com/sayjong/backend/training/domain/TrainingSession.java
+++ b/src/main/java/com/sayjong/backend/training/domain/TrainingSession.java
@@ -45,9 +45,20 @@ public class TrainingSession {
     @Column
     private LocalDateTime lastPlayedAt; // 최근에 학습한 노래 순으로 화면에 띄워주기 위해 추가
 
+    // 처음 생성될 때 시간 초기화
+    @PrePersist
+    public void prePersist() {
+        if (this.lastPlayedAt == null) {
+            this.lastPlayedAt = LocalDateTime.now();
+        }
+    }
+
     // 점수 업데이트
-    public void updateScores(int newScore) {
+    public void updateScores(int newScore, int newAverageScore) {
         this.recentScore = newScore;
+        this.averageScore = newAverageScore;
+
+        this.lastPlayedAt = LocalDateTime.now();
 
         // 최고 점수가 비어있거나, 새 점수가 더 높으면 최고 점수 갱신
         if (this.bestScore == null || newScore > this.bestScore) {

--- a/src/main/java/com/sayjong/backend/training/dto/response/TrainingSessionResponseDto.java
+++ b/src/main/java/com/sayjong/backend/training/dto/response/TrainingSessionResponseDto.java
@@ -1,0 +1,37 @@
+package com.sayjong.backend.training.dto.response;
+
+import com.sayjong.backend.training.domain.TrainingSession;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TrainingSessionResponseDto {
+    private Integer sessionId;
+    private Integer averageScore;
+    private Integer bestScore;
+    private Integer recentScore;
+    private LocalDateTime lastPlayedAt;
+
+    // 노래 정보
+    private Integer songId;
+    private String title;
+    private String singer;
+    private String coverUrl;
+
+    public static TrainingSessionResponseDto from(TrainingSession session) {
+        return TrainingSessionResponseDto.builder()
+                .sessionId(session.getSessionId())
+                .averageScore(session.getAverageScore())
+                .bestScore(session.getBestScore())
+                .recentScore(session.getRecentScore())
+                .lastPlayedAt(session.getLastPlayedAt())
+                .songId(session.getSong().getSongId())
+                .title(session.getSong().getTitle())
+                .singer(session.getSong().getSinger())
+                .coverUrl(session.getSong().getCoverUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/sayjong/backend/training/dto/response/TrainingSessionResponseDto.java
+++ b/src/main/java/com/sayjong/backend/training/dto/response/TrainingSessionResponseDto.java
@@ -17,7 +17,7 @@ public class TrainingSessionResponseDto {
 
     // 노래 정보
     private Integer songId;
-    private String title;
+    private String titleEng;
     private String singer;
     private String coverUrl;
 
@@ -29,7 +29,7 @@ public class TrainingSessionResponseDto {
                 .recentScore(session.getRecentScore())
                 .lastPlayedAt(session.getLastPlayedAt())
                 .songId(session.getSong().getSongId())
-                .title(session.getSong().getTitle())
+                .titleEng(session.getSong().getTitleEng())
                 .singer(session.getSong().getSinger())
                 .coverUrl(session.getSong().getCoverUrl())
                 .build();

--- a/src/main/java/com/sayjong/backend/training/repository/ScoreHistoryRepository.java
+++ b/src/main/java/com/sayjong/backend/training/repository/ScoreHistoryRepository.java
@@ -2,6 +2,8 @@ package com.sayjong.backend.training.repository;
 
 import com.sayjong.backend.training.domain.ScoreHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -9,4 +11,8 @@ public interface ScoreHistoryRepository extends JpaRepository<ScoreHistory, Inte
 
     // 사용자의 특정 세션에 대한 모든 점수 기록을 조회
     List<ScoreHistory> findByUserUserIdAndSessionSessionIdOrderByScoredAtDesc(Integer userId, Integer sessionId);
+
+    // 특정 세션의 점수 평균을 계산
+    @Query("SELECT COALESCE(AVG(s.score), 0) FROM ScoreHistory s WHERE s.session.sessionId = :sessionId")
+    Double findAverageScoreBySessionId(@Param("sessionId") Integer sessionId);
 }

--- a/src/main/java/com/sayjong/backend/training/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/sayjong/backend/training/repository/TrainingSessionRepository.java
@@ -4,9 +4,15 @@ import com.sayjong.backend.training.domain.TrainingSession;
 import com.sayjong.backend.song.domain.Song;
 import com.sayjong.backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface TrainingSessionRepository extends JpaRepository<TrainingSession, Integer> {
 
+    // 점수 저장용
     Optional<TrainingSession> findByUserAndSong(User user, Song song);
+
+    // 전체 목록 조회
+    List<TrainingSession> findAllByUserOrderByLastPlayedAtDesc(User user);
 }

--- a/src/main/java/com/sayjong/backend/training/service/TrainingSessionService.java
+++ b/src/main/java/com/sayjong/backend/training/service/TrainingSessionService.java
@@ -1,0 +1,35 @@
+package com.sayjong.backend.training.service;
+
+import com.sayjong.backend.training.domain.TrainingSession;
+import com.sayjong.backend.training.dto.response.TrainingSessionResponseDto;
+import com.sayjong.backend.training.repository.TrainingSessionRepository;
+import com.sayjong.backend.user.domain.User;
+import com.sayjong.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TrainingSessionService {
+
+    private final TrainingSessionRepository trainingSessionRepository;
+    private final UserRepository userRepository;
+
+    public List<TrainingSessionResponseDto> getMySessions(String username) {
+        User user = userRepository.findByLoginId(username)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        // 전체 조회 (최신순)
+        List<TrainingSession> sessions = trainingSessionRepository.findAllByUserOrderByLastPlayedAtDesc(user);
+
+        return sessions.stream()
+                .map(TrainingSessionResponseDto::from)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- **학습 내용 조회 api 구현**:` /api/users/me/training-sessions`
- trainingSession도메인에 평균 점수, 마지막으로 학습한 시간(마지막으로 학습한 노래 순서대로 정렬하기 위해) 필드 추가
- 점수 저장 api(`/api/users/me/songs/{songId}/scores`)가 호출되면 ScoreHistoryService에서 점수를 scoreHistory 데이터베이스에 저장하는 동시에 trainingSession의 평균점수, 최근점수, 최고점수, 마지막으로 학습한 시간 필드도 함께 갱신해주도록 수정했습니다.

### 실행화면 캡처
- **아래와 같이 사용자가 같은 노래에 대해 처음에는 80점, 그 후에는 90점을 받았다면**
<img width="695" height="632" alt="스크린샷 2025-11-18 오후 8 36 29" src="https://github.com/user-attachments/assets/d6695291-3dba-4364-8a92-af9534c67bf4" />

- **학습 내용 조회 시, 평균 점수=85, 최고 점수=90, 최근점수=90으로 뜨며, 가장 최근에 학습한 시간이 기록되는 것을 확인할 수 있음**
<img width="695" height="632" alt="스크린샷 2025-11-18 오후 8 36 43" src="https://github.com/user-attachments/assets/68e25ecc-f09c-43f4-b2d2-ff95d83d1470" />

- **만약 사용자가 그 후 다른 노래를 학습한다면, 최근에 학습한 노래가 가장 상단에 뜨도록 함**
<img width="695" height="725" alt="스크린샷 2025-11-18 오후 8 37 03" src="https://github.com/user-attachments/assets/18dc37d6-652f-45cf-98e5-6ef7a38b6331" />

